### PR TITLE
Vk dspace publisher optimization

### DIFF
--- a/src/main/java/bwfdm/replaydh/workflow/export/dspace/DSpaceRepository.java
+++ b/src/main/java/bwfdm/replaydh/workflow/export/dspace/DSpaceRepository.java
@@ -1,0 +1,179 @@
+/*
+ * Unless expressly otherwise stated, code from this project is licensed under the MIT license [https://opensource.org/licenses/MIT].
+ * 
+ * Copyright (c) <2018> <Markus Gärtner, Volodymyr Kushnarenko, Florian Fritze, Sibylle Hermann and Uli Hahn>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A 
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT 
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH 
+ * THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package bwfdm.replaydh.workflow.export.dspace;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.swordapp.client.AuthCredentials;
+import org.swordapp.client.ProtocolViolationException;
+import org.swordapp.client.SWORDClient;
+import org.swordapp.client.SWORDClientException;
+import org.swordapp.client.SWORDCollection;
+import org.swordapp.client.SWORDWorkspace;
+import org.swordapp.client.ServiceDocument;
+import org.swordapp.client.UriRegistry;
+
+/**
+ * The class consists implementation of some general purpose DSpace-specific methods.
+ * It should be used as a parent for further child-classes as e.g. DSpace_v6, Dspace_v5.
+ * 
+ * @author Volodymyr Kushnarenko
+ *
+ */
+public abstract class DSpaceRepository implements PublicationRepository{
+
+	private static final Logger log = LoggerFactory.getLogger(DSpaceRepository.class);
+	
+	// Header constants
+	public static final String APPLICATION_JSON = "application/json";
+	public static final String CONTENT_TYPE_HEADER = "Content-Type";
+	public static final String ACCEPT_HEADER = "Accept";
+	
+	
+	/*
+	 * -------------------------------
+	 * General purpose methods
+	 * -------------------------------
+	 */
+	
+	
+	/**
+	 * Get new authentication credentials. 
+	 * <p> To disactivate "on-behalf-of" option please use the same string for "adminUser" and "userLogin".
+	 * <p> If "adminUser" and "userLogin" are different, "on-behalf-of" option will be used.
+	 * 
+	 * @param adminUser
+	 * @param adminPassword
+	 * @param userLogin
+	 * @return
+	 */
+	public static AuthCredentials getNewAuthCredentials(String adminUser, char[] adminPassword, String userLogin) {
+		
+		if(adminUser.equals(userLogin)) {
+			return new AuthCredentials(userLogin, String.valueOf(adminPassword)); // without "on-behalf-of"
+		} else {
+			return new AuthCredentials(adminUser, String.valueOf(adminPassword), userLogin); // with "on-behalf-of"
+		}
+	}
+	
+	
+	/**
+	 * Get service document via SWORD v2
+	 * 
+	 * @param swordClient
+	 * @param serviceDocumentURL
+	 * @param authCredentials
+	 * @return ServiceDocument or null in case of error/exception
+	 */
+	public static ServiceDocument getServiceDocument(SWORDClient swordClient, String serviceDocumentURL, AuthCredentials authCredentials) {
+		ServiceDocument serviceDocument = null;
+		try {
+			serviceDocument = swordClient.getServiceDocument(serviceDocumentURL, authCredentials);
+		} catch (SWORDClientException | ProtocolViolationException e) {
+			log.error("Exception by accessing service document: " + e.getClass().getSimpleName() + ": " + e.getMessage());
+			return null;
+		}
+		return serviceDocument;
+	}
+	
+	
+	/**
+	 * Get available collections via SWORD v2
+	 * 
+	 * @return Map<String, String> where key=URL, value=Title
+	 */
+	public static Map<String, String> getAvailableCollectionsViaSWORD(ServiceDocument serviceDocument){
+		Map<String, String> collections = new HashMap<String, String>();
+		
+		if(serviceDocument != null) {
+			for(SWORDWorkspace workspace : serviceDocument.getWorkspaces()) {
+				for (SWORDCollection collection : workspace.getCollections()) {
+					// key = full URL, value = Title
+					collections.put(collection.getHref().toString(), collection.getTitle());
+				}
+			}
+		}
+		return collections;
+	}
+	
+	
+	/**
+	 * Get a file extension (without a dot) from the file name (e.g. "txt", "zip", ...)
+	 * @param fileName
+	 * @return
+	 */
+	public static String getFileExtension(String fileName) {	
+		String extension = "";
+		int i = fileName.lastIndexOf('.');
+		if(i>0) {
+			extension = fileName.substring(i+1);
+		}
+		return extension;		
+	}
+	
+	
+	/**
+	 * Get package format basing on the file name.
+	 * E.g. {@link UriRegistry.PACKAGE_SIMPLE_ZIP} {@link UriRegistry.PACKAGE_BINARY}
+	 * @param fileName
+	 * @return 
+	 */
+	public static String getPackageFormat(String fileName) {
+		String extension = getFileExtension(fileName);
+		
+		if(extension.toLowerCase().equals("zip")) {
+			return UriRegistry.PACKAGE_SIMPLE_ZIP;
+		}
+		return UriRegistry.PACKAGE_BINARY;
+	}
+		
+	
+	/*
+	 * -------------
+	 * Extra classes
+	 * -------------
+	 */
+	
+	
+	public static enum SwordRequestType {	
+		DEPOSIT("DEPOSIT"), //"POST" request
+		REPLACE("REPLACE"), //"PUT" request
+		DELETE("DELETE")	//reserved for the future
+		;
+		
+		private final String label;
+		
+		private SwordRequestType(String label) {
+			this.label = label;
+		}
+		
+		public String getLabel() {
+			return label;
+		}
+		
+		@Override
+		public String toString() {
+			return label;
+		}
+	}
+		
+}

--- a/src/main/java/bwfdm/replaydh/workflow/export/dspace/DSpace_v6.java
+++ b/src/main/java/bwfdm/replaydh/workflow/export/dspace/DSpace_v6.java
@@ -111,7 +111,7 @@ public class DSpace_v6 implements PublicationRepository{
 	 * @param userLogin
 	 * @return
 	 */
-	private AuthCredentials getNewAuthCredentials(String adminUser, char[] adminPassword, String userLogin) {
+	protected AuthCredentials getNewAuthCredentials(String adminUser, char[] adminPassword, String userLogin) {
 		
 		if(adminUser.equals(userLogin)) {
 			return new AuthCredentials(userLogin, String.valueOf(adminPassword)); // without "on-behalf-of"
@@ -129,7 +129,7 @@ public class DSpace_v6 implements PublicationRepository{
 	 * @param authCredentials
 	 * @return ServiceDocument or null in case of error/exception
 	 */
-	private ServiceDocument getServiceDocument(SWORDClient swordClient, String serviceDocumentURL, AuthCredentials authCredentials) {
+	protected ServiceDocument getServiceDocument(SWORDClient swordClient, String serviceDocumentURL, AuthCredentials authCredentials) {
 		ServiceDocument serviceDocument = null;
 		try {
 			serviceDocument = swordClient.getServiceDocument(this.serviceDocumentURL, authCredentials);
@@ -146,7 +146,7 @@ public class DSpace_v6 implements PublicationRepository{
 	 * 
 	 * @return Map<String, String> where key=URL, value=Title
 	 */
-	private Map<String, String> getAvailableCollectionsViaSWORD(ServiceDocument serviceDocument){
+	protected Map<String, String> getAvailableCollectionsViaSWORD(ServiceDocument serviceDocument){
 		Map<String, String> collections = new HashMap<String, String>();
 		
 		if(serviceDocument != null) {
@@ -165,7 +165,7 @@ public class DSpace_v6 implements PublicationRepository{
 	 * @param fileName
 	 * @return
 	 */
-	private String getFileExtension(String fileName) {	
+	protected String getFileExtension(String fileName) {	
 		String extension = "";
 		int i = fileName.lastIndexOf('.');
 		if(i>0) {
@@ -181,7 +181,7 @@ public class DSpace_v6 implements PublicationRepository{
 	 * @param fileName
 	 * @return 
 	 */
-	private String getPackageFormat(String fileName) {
+	protected String getPackageFormat(String fileName) {
 		String extension = this.getFileExtension(fileName);
 		
 		if(extension.toLowerCase().equals("zip")) {
@@ -278,7 +278,7 @@ public class DSpace_v6 implements PublicationRepository{
 	 * @return a {@code List<String>} of communities (0 or more communities are possible) 
 	 * 		   or {@code null} if a collection was not found
 	 */
-	private List<String> getCommunitiesForCollection(String collectionURL, ServiceDocument serviceDocument, HierarchyObject hierarchy, CollectionObject[] existedCollectionObjects){
+	protected List<String> getCommunitiesForCollection(String collectionURL, ServiceDocument serviceDocument, HierarchyObject hierarchy, CollectionObject[] existedCollectionObjects){
 		
 		String collectionHandle = getCollectionHandle(collectionURL, serviceDocument, existedCollectionObjects);
 		if(collectionHandle == null) {
@@ -302,7 +302,7 @@ public class DSpace_v6 implements PublicationRepository{
 	 * Get a complete hierarchy of collections as HierarchyObject. REST is used. Works up DSpace-6.
 	 * @return {@link HierarchyObject}
 	 */
-	private HierarchyObject getHierarchyObject() {
+	protected HierarchyObject getHierarchyObject() {
 		
 		final CloseableHttpResponse response = WebUtils.getResponse(this.client, this.hierarchyURL, RequestType.GET, APPLICATION_JSON, APPLICATION_JSON);
 		final HierarchyObject hierarchy = JsonUtils.jsonStringToObject(
@@ -343,7 +343,7 @@ public class DSpace_v6 implements PublicationRepository{
 	 * @param serviceDocument
 	 * @return String with a handle or {@code null} if collectionURL was not found 
 	 */
-	private String getCollectionHandle(String collectionURL, ServiceDocument serviceDocument, CollectionObject[] existedCollections) {
+	protected String getCollectionHandle(String collectionURL, ServiceDocument serviceDocument, CollectionObject[] existedCollections) {
 		
 		String swordCollectionPath = ""; //collectionURL without a hostname and port
 		
@@ -369,7 +369,7 @@ public class DSpace_v6 implements PublicationRepository{
 	 * Get all existed collections as an array of CollectionObject. REST is used.
 	 * @return
 	 */
-	private CollectionObject[] getAllCollectionObjects() {
+	protected CollectionObject[] getAllCollectionObjects() {
 		
 		final CloseableHttpResponse response = WebUtils.getResponse(this.client, this.collectionsURL, RequestType.GET, APPLICATION_JSON, APPLICATION_JSON);
 		final CollectionObject[] collections = JsonUtils.jsonStringToObject(
@@ -396,7 +396,7 @@ public class DSpace_v6 implements PublicationRepository{
 	 *  	   "StatusCode" parameter from the response in case of {@code SwordRequestType.REPLACE} request,
 	 *  	   or {@code null} in case of error
 	 */
-	private String publishElement(String userLogin, String collectionURL, SwordRequestType swordRequestType, String mimeFormat, String packageFormat, File file, Map<String, String> metadataMap) {
+	protected String publishElement(String userLogin, String collectionURL, SwordRequestType swordRequestType, String mimeFormat, String packageFormat, File file, Map<String, String> metadataMap) {
 		
 		// Check if only 1 parameter is used (metadata OR file). 
 		// Multipart is not supported.
@@ -522,7 +522,7 @@ public class DSpace_v6 implements PublicationRepository{
 	 * @param swordRequestType
 	 * @return
 	 */
-	private boolean publishMetadata(String userLogin, String collectionURL, Map<String, String> metadataMap, SwordRequestType swordRequestType) {
+	protected boolean publishMetadata(String userLogin, String collectionURL, Map<String, String> metadataMap, SwordRequestType swordRequestType) {
 		
 		String mimeFormat = "application/atom+xml";
 		String packageFormat = UriRegistry.PACKAGE_BINARY;
@@ -559,7 +559,7 @@ public class DSpace_v6 implements PublicationRepository{
 	 * @param swordRequestType
 	 * @return
 	 */
-	private boolean publishMetadata(String userLogin, String collectionURL, File metadataFileXML, SwordRequestType swordRequestType) {
+	protected boolean publishMetadata(String userLogin, String collectionURL, File metadataFileXML, SwordRequestType swordRequestType) {
 		
 		// Check if file has an XML-extension
 		if(!getFileExtension(metadataFileXML.getName()).toLowerCase().equals("xml")) {

--- a/src/main/java/bwfdm/replaydh/workflow/export/dspace/WebUtils.java
+++ b/src/main/java/bwfdm/replaydh/workflow/export/dspace/WebUtils.java
@@ -1,0 +1,176 @@
+/*
+ * Unless expressly otherwise stated, code from this project is licensed under the MIT license [https://opensource.org/licenses/MIT].
+ * 
+ * Copyright (c) <2018> <Markus Gärtner, Volodymyr Kushnarenko, Florian Fritze, Sibylle Hermann and Uli Hahn>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A 
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT 
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH 
+ * THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package bwfdm.replaydh.workflow.export.dspace;
+
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import org.apache.http.ParseException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WebUtils {
+
+	protected static final Logger log = LoggerFactory.getLogger(WebUtils.class);
+	
+	
+	/** 
+	 * Create a ClosableHttpClient with ignoring of SSL certificates
+	 * @return
+	 */
+	public static CloseableHttpClient createHttpClientWithSSLSupport() {
+		
+		try {
+			KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+			
+			SSLContextBuilder builder = new SSLContextBuilder();
+			builder.loadTrustMaterial(trustStore, new TrustSelfSignedStrategy() {
+				@Override
+			    public boolean isTrusted(X509Certificate[] chain, String authType)
+			            throws CertificateException {
+			        return true;
+			    }
+			});
+			SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(builder.build());	
+			return HttpClients.custom().setSSLSocketFactory(
+		            sslsf).setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE).build();
+			
+			//return HttpClients.custom().setSSLSocketFactory(sslsf).build();
+			
+		} catch (NoSuchAlgorithmException | KeyStoreException | KeyManagementException e) {
+			log.error("Exception by creation of http-clinet with ssl support: " + e.getClass() + ": " + e.getMessage());
+			e.printStackTrace();
+			return null;
+		}		
+	}
+		
+	
+	/**
+	 * Get a response to the REST-request
+	 * 
+	 * @param client
+	 * @param url
+	 * @param contentType
+	 * @param acceptType
+	 * @return
+	 */
+	public static CloseableHttpResponse getResponse(CloseableHttpClient client, String url, RequestType requestType, String contentType, String acceptType) {
+		try {
+			HttpUriRequest request;
+			switch (requestType) {
+			case GET:
+				request = new HttpGet(url);
+				break;
+			case PUT:
+				request = new HttpPut(url);
+				break;
+			case POST:
+				request = new HttpPost(url);
+				break;
+			default:
+				log.error("Not supported request type: " + requestType.toString());
+				return null;
+			}
+			
+			request.addHeader("Content-Type", contentType);
+			request.addHeader("Accept", acceptType);
+			CloseableHttpResponse response = client.execute(request);
+			return response;
+			
+		} catch (IOException e) {
+			log.error("Exception by http request: " + e.getClass().getSimpleName() + ": " + e.getMessage());
+			return null;
+		}
+	}
+	
+	
+	/**
+	 * Get a response entity as a String
+	 * 
+	 * @param response
+	 * @return
+	 */
+	public static String getResponseEntityAsString(CloseableHttpResponse response) {
+		try {
+			return EntityUtils.toString(response.getEntity(),"UTF-8");
+		} catch (ParseException | IOException e) {
+			log.error("Exception by converting response entity to String: " 
+						+ e.getClass().getSimpleName() + ": " + e.getMessage());
+			return null;			
+		} 
+	}
+	
+	
+	/**
+	 * Close response
+	 * @param response
+	 */
+	public static void closeResponse(CloseableHttpResponse response) {
+		try {
+			response.close();
+		} catch (IOException e) {
+			log.error("Exception by response closing: "	+ e.getClass().getSimpleName() + ": " + e.getMessage());
+		}
+	}
+	
+	
+	/**
+	 * Possible types of request
+	 * @author Volodymyr Kushnarenko
+	 */
+	public static enum RequestType {	
+		GET("GET"),
+		PUT("PUT"),
+		POST("POST")
+		;
+		
+		private final String label;
+		
+		private RequestType(String label) {
+			this.label = label;
+		}
+		
+		public String getLabel() {
+			return label;
+		}
+		
+		@Override
+		public String toString() {
+			return label;
+		}
+	}
+	
+}

--- a/src/main/resources/bwfdm/replaydh/resources/localization.properties
+++ b/src/main/resources/bwfdm/replaydh/resources/localization.properties
@@ -412,6 +412,7 @@ replaydh.wizard.dspacePublisher.chooseRepository.loginButton            = Check 
 replaydh.wizard.dspacePublisher.chooseRepository.loginInfoButton        = Read login info in browser
 replaydh.wizard.dspacePublisher.chooseRepository.loginLabel             = Login
 replaydh.wizard.dspacePublisher.chooseRepository.passwordLabel          = Password
+replaydh.wizard.dspacePublisher.chooseRepository.pleaseLoginMessage     = Please login.
 replaydh.wizard.dspacePublisher.chooseRepository.successMessage         = Login is successful! \r\nPlease go to the next step.
 replaydh.wizard.dspacePublisher.chooseRepository.terminationMessage     = Publication repository connection problem. \r\nPlease check the Interent connection and repository-URL.
 replaydh.wizard.dspacePublisher.chooseRepository.title                  = Login

--- a/src/main/resources/bwfdm/replaydh/resources/localization_de.properties
+++ b/src/main/resources/bwfdm/replaydh/resources/localization_de.properties
@@ -265,6 +265,7 @@ replaydh.wizard.dspacePublisher.chooseRepository.loginButton            = Login 
 replaydh.wizard.dspacePublisher.chooseRepository.loginInfoButton        = Login Info im Browser lesen
 replaydh.wizard.dspacePublisher.chooseRepository.loginLabel             = Login
 replaydh.wizard.dspacePublisher.chooseRepository.passwordLabel          = Passwort
+replaydh.wizard.dspacePublisher.chooseRepository.pleaseLoginMessage     = Loggen Sie bitte ein.
 replaydh.wizard.dspacePublisher.chooseRepository.successMessage         = Login ist erfolgreich! \r\nBitte gehen Sie zum n\u00E4chsten Schritt.
 replaydh.wizard.dspacePublisher.chooseRepository.terminationMessage     = Problem bei der Verbindung an Repositorium.\r\nPr\u00FCfen Sie bitte die Internet Verbindung und URL vom Repositorium.
 replaydh.wizard.dspacePublisher.chooseRepository.title                  = Login


### PR DESCRIPTION
Was done:
* removed recursive requests to the pub-repo which caused very long delay (and timeout exception) in case of large amount of available collections. To be sure, timeout is increased now to 60 sec.
* implemented and separate POST and PUT requests in terms of SWORD (deposit and replace). It solves a problem of duplicated metadata by publication of archive with separate metadata.
* started to use common RDH-methods to show red borders for text fields in case of errors, added "please-login" label to wizard, set URL as only "not-editable", what increase readability 
* code refactoring, new class WebUtils with common used http-methods
* moved general purpose for DSpace methods to new class "DSpaceRepository" which will be used later as a parent for all DSpace classes (e.g. DSpace_v6, DSpace_v5, ...)